### PR TITLE
Use native private class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Typescript to emit ES2022 code
+
 ## [1.0.0] - 2025-05-31
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.33.0",
         "vitest": "^3.1.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "files": [
     "./dist"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "target": "ES2020",
+    "target": "ES2022",
     "alwaysStrict": true,
     "declarationMap": true,
     "declaration": true,


### PR DESCRIPTION
We use private class methods by using the [private identifier][1]. Our current TypeScript configuration translates these to helper functions which look really ugly.

Since we only support Node18 anyways, we are now upgrading our TypeScript configuration to generate native code for those private identifiers.

[1] https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-PrivateIdentifier